### PR TITLE
Fix Vercel deploy: restore valid pnpm workspace config

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,5 +76,15 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^7.0.2",
     "vite": "^8.1.5"
+  },
+  "pnpm": {
+    "allowBuilds": {
+      "@clerk/shared": true,
+      "esbuild": true
+    },
+    "onlyBuiltDependencies": [
+      "@clerk/shared",
+      "esbuild"
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,0 @@
-allowBuilds:
-  '@clerk/shared': true
-  esbuild: true
-onlyBuiltDependencies:
-  - "@clerk/shared"
-  - esbuild


### PR DESCRIPTION
The "Codebase cleanup" commit deleted server/ but left pnpm-workspace.yaml with its packages field removed, leaving only allowBuilds/onlyBuiltDependencies. pnpm requires a non-empty packages list if the file exists, so pnpm install failed on every deploy with "packages field missing or empty" before the build could even run.

Move allowBuilds/onlyBuiltDependencies into package.json's pnpm key and drop pnpm-workspace.yaml, since this is no longer a monorepo.